### PR TITLE
Use BeautifulSoup to close open html tags in summary

### DIFF
--- a/content/blog/posts/2015-pgd.rst
+++ b/content/blog/posts/2015-pgd.rst
@@ -12,10 +12,10 @@ The Protein Geometry Database project (PGD) is many things to many people.
 
 The synopses on `code.osuosl.org`_ says:
 
-  "Protein Geometry Database is a specialized search engine for protein geometry.
-  It allows you to explore either protein conformation or protein covalent
-  geometry or the correlations between protein conformation and bond angles and
-  lengths."
+*"Protein Geometry Database is a specialized search engine for protein geometry.
+It allows you to explore either protein conformation or protein covalent
+geometry or the correlations between protein conformation and bond angles and
+lengths."*
 
 There's a lot of science in that paragraph; I speak code much better than I
 speak science, so let's look at the `Github Repository`_. That page says things

--- a/customfilters.py
+++ b/customfilters.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import bs4
 
 def menu_filter(pelican_pages, direct_templates):
     """
@@ -59,3 +60,10 @@ def menu_filter(pelican_pages, direct_templates):
                     child['children'].append(page.copy())
 
     return menu
+
+def close_html_tags(html_string):
+    """Closes any html tags in html_string that have been opened but have not
+    been closed.
+    """
+    soup = bs4.BeautifulSoup(html_string, "html.parser")
+    return soup

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -5,9 +5,10 @@ from __future__ import unicode_literals
 import sys
 sys.path.append('.')
 
-import menufilter
+import customfilters
 
-JINJA_FILTERS = {'menu_filter':menufilter.menu_filter}
+JINJA_FILTERS = {'menu_filter':customfilters.menu_filter,
+                 'close_html_tags':customfilters.close_html_tags }
 
 AUTHOR = u'OSUOSL'
 SITENAME = u'OSU Open Source Lab'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dateutil==2.4.2
 pytz==2015.4
 six==1.9.0
 wsgiref==0.1.2
+beautifulsoup4==4.4.1


### PR DESCRIPTION
Fixes #26 

Simple BeautifulSoup filter to close any open html tags in the truncated summary for the front-page slideshow.

- [x] Merge theme PR: https://github.com/osuosl/dougfir-pelican-theme/pull/19 
- [x] Update subrepo commit
- [ ] Merge this PR