### PR TITLE
Updating Content

### DIFF
--- a/content/about/about_people.rst
+++ b/content/about/about_people.rst
@@ -63,7 +63,7 @@ justice.
 
   **Github Account:**
 
-\https://github.com/borcean
+https://github.com/borcean
 
 .. raw:: html
 
@@ -140,7 +140,7 @@ and two dogs.
 
   **Github Account:**
 
-\https://github.com/jordane
+https://github.com/jordane
 
 .. raw:: html
 
@@ -168,7 +168,7 @@ software and education to people around the world.
 
   **Github Account:**
 
-\https://github.com/fahlmant
+https://github.com/fahlmant
 
 .. raw:: html
 
@@ -194,7 +194,7 @@ the Protein Geometry Database. Megan enjoys reading in her spare time.
 
   **Github Account:**
 
-\https://github.com/MaraJade
+https://github.com/MaraJade
 
 .. raw:: html
 
@@ -220,7 +220,7 @@ his spare time he likes to spend time with his wife and kids.
 
   **Github Account:**
 
-\https://github.com/matthewrsj
+https://github.com/matthewrsj
 
 .. raw:: html
 
@@ -247,7 +247,7 @@ reading, programming and attending OSU Linux Users Group meetings.
 
   **Github Account:**
 
-\https://github.com/iankronquist
+https://github.com/iankronquist
 
 .. raw:: html
 
@@ -345,7 +345,7 @@ the internet, and programs personal projects.
 
   **Github Account:**
 
-\https://github.com/LyonesGamer
+https://github.com/LyonesGamer
 
 .. raw:: html
 
@@ -416,7 +416,7 @@ school and travel back to Hungary in the future. His PGP ID is 062FD895
 
   **Github Account:**
 
-\https://github.com/dspt/
+https://github.com/pono/
 
 .. raw:: html
 
@@ -442,7 +442,7 @@ Hearts and Skyrim are her favorites) draw, read, and sleep in her spare time.
 
   **Github Account:**
 
-\https://github.com/athai
+https://github.com/athai
 
 .. raw:: html
 
@@ -491,29 +491,7 @@ climb some of Oregon’s famous climbing rocks.
 
   **Github Account:**
 
-\http://github.com/tschuy
-
-.. raw:: html
-
-  <br/>
-
-`Rachel Turner`_
-----------------
-
-.. image:: /images/rturner.jpg
-    :scale: 50%
-    :align: right
-    :alt: Rachel Turner
-
-.. class:: no-breaks
-
-  **Writer | Thesaurus Rex**
-
-Rachel is a speech communication major who joined the OSL team in March 2014;
-she is responsible for writing and editing articles and Web content for the
-OSL. Rachel is a member of the OSU Speech and Debate team and hopes to write
-speeches once she graduates. In her spare time, she enjoys reading, watching
-movies and traveling.
+http://github.com/tschuy
 
 .. raw:: html
 
@@ -541,7 +519,7 @@ number of solo open source projects and watches “Doctor Who.”
 
   **Github Account:**
 
-\https://github.com/mathuin
+https://github.com/mathuin
 
 .. raw:: html
 
@@ -569,7 +547,7 @@ hoping to start his own software company.
 
   **Github Account:**
 
-\https://github.com/ElijahCaine
+https://github.com/ElijahCaine
 
 .. raw:: html
 
@@ -600,7 +578,7 @@ developers.
 
   **Github Account:**
 
-\https://github.com/lucywyman
+https://github.com/lucywyman
 
 .. raw:: html
 

--- a/content/donate/donate_faq.rst
+++ b/content/donate/donate_faq.rst
@@ -68,15 +68,14 @@ http://osufoundation.org
 to match my donation to the OSUOSL?**
 
 Many corporations have programs which will match donations to educational
-institutions. The OSU Foundation has instructions for many companies listed
-here:
+institutions. The OSU Foundation can help you find out if your company has a
+matching gift policy `here`_.
 
-https://osufoundation.org/giving/company_match.htm
-
-If you don't find your employer in that list, or have further questions, please
+If you don't find your employer or have further questions, please
 contact your employer or the OSU Foundation directly to find out if your
 donation is eligible for a matching program.
 
+.. _here: http://www.osufoundation.org/s/359/foundation/index.aspx?sid=359&gid=34&pgid=4358
 
 .. _How much money are you trying to raise?:
 

--- a/content/services/hosting/communities.rst
+++ b/content/services/hosting/communities.rst
@@ -9,10 +9,10 @@ Hosted Communities
 -----------
 
 `Ångström`_ was started by a small group of people who worked on the
-OpenEmbedded, OpenZaurus and OpenSimpad projects to unify their effort to make a
-stable and user-friendly distribution for embedded devices like handhelds,
-set-top boxes and network-attached storage devices and more. The OSL hosts their
-Narcissus Image Builder via the Nas-Admin.org project.
+OpenEmbedded, OpenZaurus and OpenSimpad projects to unify their effort to make
+a stable and user-friendly distribution for embedded devices like handhelds,
+set-top boxes and network-attached storage devices and more. The OSL hosts
+their Narcissus Image Builder via the Nas-Admin.org project.
 
 .. _Ångström: http://www.angstrom-distribution.org/
 
@@ -572,21 +572,21 @@ network that aims to provide stable and effective collaboration services to
 members of the community in any part of the world, while closely listening to
 their needs and desires. The OSL hosts a node of the OFTC IRC network.
 
-.. _Open and Free Technology Communicty: http://oftc.net/
+.. _Open and Free Technology Community: http://oftc.net/
 .. _Open and Free Technology Community (OFTC): http://oftc.net/
 
 
-`Open Source Digital Voting Foundation`_
------------------------------------------
+`Open Source Elections Technology Foundation`_
+-----------------------------------------------
 
-The `OSDV Foundation`_ is building an open source election technology framework
+The `OSET Foundation`_ is building an open source election technology framework
 for adoption and deployment by U.S. jurisdictions. The OSL hosts websites for
 the foundation, the development servers for the TrustTheVote project and
 application servers for their partner `RockTheVote`_’s voter registration
 project.
 
-.. _Open Source Digital Voting Foundation: http://osdv.org/
-.. _OSDV Foundation: http://osdv.org/
+.. _Open Source Elections Technology Foundation: http://osetfoundation.org/
+.. _OSET Foundation: http://osetfoundation.org/
 .. _RockTheVote: http://www.rockthevote.org/
 
 

--- a/content/services/hosting/communities.rst
+++ b/content/services/hosting/communities.rst
@@ -35,7 +35,7 @@ with the Renderman® interface standard defined by Pixar. The OSL provides
 hosting for a server and a Xen virtual machine for handling the Web, mail and
 development needs of Aqsis.
 
-.. _Aqsis: http://aqsis.org/
+.. _Aqsis: http://www.aqsis.org/
 
 
 `BusyBox`_

--- a/content/services/services_development.rst
+++ b/content/services/services_development.rst
@@ -34,7 +34,7 @@ cloud infrastructure. With a caching system designed to scale to many thousands
 of virtual machines without decreasing performance, GWM makes private cluster
 management for administrators truly simple.
 
-.. _Ganeti Web Manager: https://code.osuosl.org.projects/51
+.. _Ganeti Web Manager: https://github.com/osuosl/ganeti_webmgr
 
 
 `Oregon Virtual School District`_
@@ -57,7 +57,7 @@ use by researchers in OSU's biochemistry department. PGD provides an online
 search tool used to mine protein conformational space with a user-friendly but
 surprisingly flexible graphical interface.
 
-.. _Protein Geometry Database: http://pgd.osuosl.org
+.. _Protein Geometry Database: https://github.com/osuosl/pgd
 
 
 `TriSano`_


### PR DESCRIPTION
Fixes #36. 

* The link to the privacy policy in the donate FAQ is broken (where is the privacy policy located on the osu foundation site, by the way? I can't find it)
* @borcean said that the osl is no longer hosting MeeGo. Is there anything else that should be removed from the list of hosted projects? Mozdev, GOSCON, and KernelTrap all have broken links. 

Other things to consider:
* services/hosting/details: maintain.osuosl.org and FTP Map
* services/development: What's the status on TriSano? Their website doesn't seem to work anymore but I found their github: https://github.com/csinitiative/trisano
* services/supercell: Lance's LinuxCon 2010 slides cannot be accessed