### PR TITLE
Parent organization (CASS) pelican variables

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -52,6 +52,8 @@ YOUTUBEURL = 'http://youtube.com/osuopensourcelab'
 GPLUSURL = 'https://plus.google.com/107361178205293595706?rel=author'
 
 DEP_NAME = 'OSU Open Source Lab'
+PARENT_ORG = 'Center for Applied Systems & Software'
+PARENT_ORG_URL = 'http://cass.oregonstate.edu/'
 SITELOGO = 'osllogo-web_0.png'
 # Uncomment following line if you want document-relative URLs when developing
 #RELATIVE_URLS = True


### PR DESCRIPTION
Satisfies part of #80 

Adds two pelican variables: parent organization name and parent organization link. For the OSL, this is "Center for Applied Systems and Software" (used to be "College of Engineering).

After this [theme PR](https://github.com/osuosl/dougfir-pelican-theme/pull/53) is merged, the site should look like this:
![cass_osl](https://cloud.githubusercontent.com/assets/9158473/18176141/3f8d9cec-7029-11e6-8288-bb37e99ffd51.png)
and the link should redirect to the CASS webpage.

Title color will be addressed in a separate PR (probably [this one](https://github.com/osuosl/dougfir-pelican-theme/pull/52)).

The CASS version of this PR is [here](https://github.com/osu-cass/cass-pelican/pull/91).

## To test:
1. ``cd osuosl-pelican``
2. ``git checkout leian/parent_org`` (git pull as necessary)
3. ``cd dougfir-pelican-theme``
4. ``git checkout leian/parent_org`` (git pull as necessary)
5. ``cd ../``
6. ``make devserver``
7. localhost:8000

@subnomo @athai @Kennric @alxngyn @kelnera 