### PR TITLE
Homepage improvements

### DIFF
--- a/content/about/about.rst
+++ b/content/about/about.rst
@@ -1,7 +1,7 @@
 About
 =====
 :slug: about
-:tag: homepage-desc
+:tag: frontpage 
 :author: Lucy Wyman
 :title: About
 :menu: top, About, 1; About, Summary, 1

--- a/content/about/about.rst
+++ b/content/about/about.rst
@@ -1,6 +1,7 @@
 About
 =====
 :slug: about
+:tag: homepage-desc
 :author: Lucy Wyman
 :title: About
 :menu: top, About, 1; About, Summary, 1
@@ -18,7 +19,7 @@ organization of its kind, the OSL offers world-class hosting services,
 professional software development and on-the-ground training for promising
 students interested in open source management and programming.
 
-.. image:: /images/edray.jpg
+.. .. image:: /images/edray.jpg
     :scale: 100%
     :align: center
     :alt: OSU President Ed Ray

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -48,6 +48,7 @@ THEME = 'dougfir-pelican-theme'
 FEATURED = u'featured-stories'
 SLIDESHOW_LIMIT = 5
 OSL_HOME_EXTRAS = True
+FRONTPAGE = u'frontpage'
 
 CATEGORY_URL = 'blog/{slug}'
 CATEGORY_SAVE_AS = 'blog/index.html'

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -44,6 +44,10 @@ DIRECT_TEMPLATE_INFO = [
 
 THEME = 'dougfir-pelican-theme'
 
+# Additional variables
+FEATURED = u'featured-stories'
+OSL_HOME_EXTRAS = True
+
 CATEGORY_URL = 'blog/{slug}'
 CATEGORY_SAVE_AS = 'blog/index.html'
 ARTICLE_PATHS = ['blog/posts/']

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -46,6 +46,7 @@ THEME = 'dougfir-pelican-theme'
 
 # Additional variables
 FEATURED = u'featured-stories'
+SLIDESHOW_LIMIT = 5
 OSL_HOME_EXTRAS = True
 
 CATEGORY_URL = 'blog/{slug}'


### PR DESCRIPTION
Will be merged alongside dougfir theme changes - https://github.com/osuosl/dougfir-pelican-theme/pull/57

- [x] Add description to homepage
- [x] Make it so that slideshow content depends on a ``featured-stories`` tag
- [x] Limit slideshow stories (Tackled in https://github.com/osuosl/dougfir-pelican-theme/pull/56)

Currently, the page looks like this:
![osl_homepage](https://cloud.githubusercontent.com/assets/6801364/18758489/2903162a-80ad-11e6-97bd-f0d00a7458ba.png)
