### PR TITLE
set form submission subject lines

### DIFF
--- a/content/forms/power-request-hosting.rst
+++ b/content/forms/power-request-hosting.rst
@@ -127,7 +127,8 @@ PowerLinux / OpenPOWER Request Form
           <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
           <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_hosting in production -->
           <input type="hidden" name="redirect" value="http://www.osuosl.org/services/powerdev/request_hosting" />
-          <input type="hidden" name="mail_subject" value="FORM: New PowerLinux/OpenPOWER Hosting Request" />
+          <input type="hidden" name="mail_subject_prefix" value="New PowerLinux/OpenPOWER Hosting Request" />
+          <input type="hidden" name="mail_subject_key" value="project_name" />
           <input type="hidden" name="send_to" value="powerdev" />
           <!-- /Formsender Settings -->
 

--- a/content/forms/request-hosting.rst
+++ b/content/forms/request-hosting.rst
@@ -71,7 +71,8 @@ Request Hosting
               <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
               <!-- The following must be set to http://www.osuosl.org/request-hosting in production -->
               <input type="hidden" name="redirect" value="http://www.osuosl.org/request-hosting" />
-              <input type="hidden" name="mail_subject" value="FORM: New Hosting Request" />
+              <input type="hidden" name="mail_subject_prefix" value="New Hosting Request" />
+              <input type="hidden" name="mail_subject_key" value="project_name" />
               <!-- /Formsender Settings -->
 
               <div class="form-actions form-wrapper" id="edit-actions">

--- a/content/forms/supercell-feedback.rst
+++ b/content/forms/supercell-feedback.rst
@@ -102,7 +102,8 @@ Supercell Feedback Form
                     <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
                     <!-- The following must be set to http://www.osuosl.org/services/supercell/request in production -->
                     <input type="hidden" name="redirect" value="http://www.osuosl.org/services/supercell/request" />
-                    <input type="hidden" name="mail_subject" value="FORM: New Supercell Feedback" />
+                    <input type="hidden" name="mail_subject_prefix" value="New Supercell Feedback" />
+                    <input type="hidden" name="mail_subject_key" value="project" />
                     <!-- /Formsender Settings -->
 
                     <div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Submit" class="form-submit" /></div>


### PR DESCRIPTION
Adds descriptive email subjects for forms, including name of the requesting project.

Testing: generate the site locally and serve with python or make devserver. Submit forms and observe the generated RT tickets.
