### PR TITLE
install markdown dependency for authoring in markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Jinja2==2.8
+Markdown==2.6.7
 MarkupSafe==0.23
 Pygments==2.0.2
 Unidecode==0.04.18


### PR DESCRIPTION
So restructured text is great, but discussion with Alex suggested being able to write posts in Markdown would be more conducive to getting students blogging. I agree, and we should allow people to write using it because it has the following benefits:

 - the language is simpler
 - they already use it for work on github
 - it's widely adopted by reddit, stackoverflow, etc.
 - the terse markup allows reviewers to focus on content rather than form
 - the failure case does not generally break the entire build

This PR adds the markdown processor, which is all I think is required to start allowing markdown documents -- pelican should autodetect them. Based on extension (.md) _I think_.