### PR TITLE
Use HTTPS over HTTP

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -52,6 +52,9 @@ SLIDESHOW_LIMIT = 5
 OSL_HOME_EXTRAS = True
 FRONTPAGE = u'frontpage'
 
+# Gudea Font
+FONT = 'https://fonts.googleapis.com/css?family=Gudea'
+
 # categories live at /blog
 CATEGORY_URL = 'blog/{slug}'
 CATEGORY_SAVE_AS = 'blog/index.html'

--- a/publishconf.py
+++ b/publishconf.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *  # noqa
 
-SITEURL = 'http://osuosl.org'
+SITEURL = 'https://osuosl.org'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'

--- a/scripts/staging_build.sh
+++ b/scripts/staging_build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Update repo
-git checkout thai/https_protocol
+git checkout staging
 git pull -q --ff-only
 git submodule update --init --recursive
 

--- a/scripts/staging_build.sh
+++ b/scripts/staging_build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Update repo
-git checkout staging
+git checkout thai/https_protocol
 git pull -q --ff-only
 git submodule update --init --recursive
 

--- a/stagingconf.py
+++ b/stagingconf.py
@@ -11,7 +11,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *  # noqa
 
 
-SITEURL = 'http://osuosl.staging.osuosl.org'
+SITEURL = 'https://osuosl.staging.osuosl.org'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
Fixes #122.

- [X] Use ``https://osuosl.org`` and ``https://osuosl.staging.osuosl.org`` as base URLs for prod and staging sites
- [X] Add ``FONT`` variable to pelicanconf.py
- [x] Use FONT var in dougfir theme (rather than hard-coded link) - [PR](https://github.com/osuosl/dougfir-pelican-theme/pull/72) 
- [x] Update submodule
- [x] Re-checkout staging in build script
