### PR TITLE
build in ./build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PELICANOPTS=
 
 BASEDIR=$(CURDIR)
 INPUTDIR=$(BASEDIR)/content
-OUTPUTDIR=$(BASEDIR)/../htdocs
+OUTPUTDIR=$(BASEDIR)/build
 CONFFILE=$(BASEDIR)/pelicanconf.py
 PUBLISHCONF=$(BASEDIR)/publishconf.py
 STAGINGCONF=$(BASEDIR)/stagingconf.py


### PR DESCRIPTION
This sets the build dir to ./build instead of ../htdocs, and is necessary for auto-building PR branches with jenkins