### PR TITLE
Emphasize how POWERDev requestors will hear back

### DIFF
--- a/content/forms/power-request-hosting.rst
+++ b/content/forms/power-request-hosting.rst
@@ -128,8 +128,8 @@ PowerLinux / OpenPOWER Request Form
             <div class="description">Is there anything additional you would like to provide for your request?</div>
           </div>
 
-          <p><i>You should receive an automated email from our request ticketing system within 5-10 minutes to the email
-          address you have provided.  If you don't receive this email please reach out to us at <a href="mailto:powerdev-request@osuosl.org">powerdev-request@osuosl.org</a> or
+          <p><i>You should receive an automated email from our request ticketing system to the email address you have provided
+          within 5-10 minutes.  If you don't receive this email please reach out to us at <a href="mailto:powerdev-request@osuosl.org">powerdev-request@osuosl.org</a> or
           via IRC in <b>#osuosl</b> on Freenode.</i></p>
 
           <!-- Formsender Settings -->

--- a/content/forms/power-request-hosting.rst
+++ b/content/forms/power-request-hosting.rst
@@ -128,9 +128,9 @@ PowerLinux / OpenPOWER Request Form
             <div class="description">Is there anything additional you would like to provide for your request?</div>
           </div>
 
-          <p>You should receive an automated email from our request ticketing system within 5-10 minutes to the email
-          address you have provided.  If you don't receive this email please reach out to us at support@osuosl.org or
-          via IRC in #osuosl on Freenode.</p>
+          <p><i>You should receive an automated email from our request ticketing system within 5-10 minutes to the email
+          address you have provided.  If you don't receive this email please reach out to us at <a href="mailto:support@osuosl.org">support@osuosl.org</a> or
+          via IRC in <b>#osuosl</b> on Freenode.</i></p>
 
           <!-- Formsender Settings -->
           <input type="hidden" name="last_name" value="" />

--- a/content/forms/power-request-hosting.rst
+++ b/content/forms/power-request-hosting.rst
@@ -129,7 +129,7 @@ PowerLinux / OpenPOWER Request Form
           </div>
 
           <p><i>You should receive an automated email from our request ticketing system within 5-10 minutes to the email
-          address you have provided.  If you don't receive this email please reach out to us at <a href="mailto:support@osuosl.org">support@osuosl.org</a> or
+          address you have provided.  If you don't receive this email please reach out to us at <a href="mailto:powerdev-request@osuosl.org">powerdev-request@osuosl.org</a> or
           via IRC in <b>#osuosl</b> on Freenode.</i></p>
 
           <!-- Formsender Settings -->


### PR DESCRIPTION
This makes the text at the end of the for a bit less hard to miss just in case they don't catch any acknowledgements.

i am not aware of anyone missing that text, but I think going an extra mile in styling won't hurt us here.