### PR TITLE
new OpenPOWER GPU request form

### DIFF
--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -106,7 +106,7 @@ PowerLinux / OpenPOWER Request Form
           <input type="hidden" name="last_name" value="" />
           <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
           <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_gpu in production -->
-          <input type="hidden" name="redirect" value="http://osuosl.org/services/powerdev/request_gpu/" />
+          <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
           <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
           <input type="hidden" name="mail_subject_key" value="project_name" />
           <input type="hidden" name="send_to" value="openpower_gpu" />

--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -95,6 +95,7 @@ PowerLinux / OpenPOWER Request Form
           <input type="hidden" name="redirect" value="http://www.osuosl.org/services/powerdev/request_gpu" />
           <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
           <input type="hidden" name="mail_subject_key" value="project_name" />
+          <input type="hidden" name="send_to" value="openpower_gpu" />
           <!-- /Formsender Settings -->
 
           <div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Submit" class="form-submit" /></div>

--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -24,13 +24,25 @@ PowerLinux / OpenPOWER Request Form
       </div>
       <form class="webform-client-form" enctype="multipart/form-data" action="http://formsender.osuosl.org:80" method="post" id="webform-client-form-1086" accept-charset="UTF-8">
         <div>
-          <div class="form-item webform-component webform-component-textfield" id="webform-component-name">
-            <label for="edit-submitted-name">Name <span class="form-required" title="This field is required.">*</span></label>
-            <input type="text" id="edit-submitted-name" name="name" value="" size="60" maxlength="128" class="form-text required" />
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-first-name">
+            <label for="edit-submitted-first-name">First name <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-first-name" name="name" value="" size="60" maxlength="128" class="form-text required" />
+          </div>
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-last-name">
+            <label for="edit-submitted-last-name">Last name <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-last-name" name="lastname" value="" size="60" maxlength="128" class="form-text required" />
           </div>
           <div class="form-item webform-component webform-component-email" id="webform-component-email">
             <label for="edit-submitted-email">Email <span class="form-required" title="This field is required.">*</span></label>
             <input class="email form-text form-email required" type="email" id="edit-submitted-email" name="email" size="60" />
+          </div>
+          <div class="form-item webform-component webform-component-phone" id="webform-component-phone">
+            <label for="edit-submitted-phone">Phone number <span class="form-required" title="This field is required.">*</span></label>
+            <input class="phone form-text form-phone required" type="phone" id="edit-submitted-phone" name="phone" size="60" />
+          </div>
+          <div class="form-item webform-component webform-component-username" id="webform-component-username">
+            <label for="edit-submitted-username">Username <span class="form-required" title="This field is required.">*</span></label>
+            <input class="username form-text form-username required" type="username" id="edit-submitted-username" name="username" size="60" />
           </div>
           <div class="form-item webform-component webform-component-textfield" id="webform-component-project-name">
             <label for="edit-submitted-project-name">Project Name <span class="form-required" title="This field is required.">*</span></label>
@@ -94,10 +106,13 @@ PowerLinux / OpenPOWER Request Form
           <input type="hidden" name="last_name" value="" />
           <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
           <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_gpu in production -->
-          <input type="hidden" name="redirect" value="http://www.osuosl.org/services/powerdev/request_gpu" />
+          <input type="hidden" name="redirect" value="http://osuosl.org/services/powerdev/request_gpu/" />
           <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
           <input type="hidden" name="mail_subject_key" value="project_name" />
           <input type="hidden" name="send_to" value="openpower_gpu" />
+          <input type="hidden" name="ibm_power" value="ibm-power" />
+          <input type="hidden" name="support" value="support" />
+          <input type="hidden" name="fields_to_join" value="username,name,lastname,phone,project_name,date,email,ibm_power,support,distribution,number_of_nodes,other_information" />
           <!-- /Formsender Settings -->
 
           <div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Submit" class="form-submit" /></div>

--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -85,17 +85,16 @@ PowerLinux / OpenPOWER Request Form
           </div>
 
           <p><i>You should receive an automated email from our request ticketing system to the email address you have provided
-          within 5-10 minutes.  If you don't receive this email please reach out to us at <a href="mailto:powerdev-request@osuosl.org">powerdev-request@osuosl.org</a> or
+          within 5-10 minutes.  If you don't receive this email please reach out to us at <a href="mailto:openpower-gpu-support@osuosl.org">openpower-gpu-support@osuosl.org</a> or
           via IRC in <b>#osuosl</b> on Freenode.</i></p>
 
           <!-- Formsender Settings -->
           <input type="hidden" name="last_name" value="" />
           <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
-          <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_hosting in production -->
+          <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_gpu in production -->
           <input type="hidden" name="redirect" value="http://www.osuosl.org/services/powerdev/request_gpu" />
           <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
           <input type="hidden" name="mail_subject_key" value="project_name" />
-          <input type="hidden" name="send_to" value="powerdev" />
           <!-- /Formsender Settings -->
 
           <div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Submit" class="form-submit" /></div>

--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -1,0 +1,104 @@
+PowerLinux / OpenPOWER Request Form
+===================================
+:slug: services/powerdev/request_gpu
+:title: OpenPOWER GPU Request Form
+:menu: POWERLinux/OpenPOWER Development Hosting, OpenPOWER GPU Request Form, 3
+
+.. raw:: html
+
+    <div id="content">
+    <!-- Formsender error script -->
+    <script src="../../../theme/js/formsender-error.js"></script>
+      <div class="field field-name-body field-type-text-with-summary field-label-hidden">
+        <div class="field-items">
+          <div class="field-item even" property="content:encoded">
+          <p>Description here.</p>
+          </div>
+        </div>
+      </div>
+      <form class="webform-client-form" enctype="multipart/form-data" action="http://formsender.osuosl.org:80" method="post" id="webform-client-form-1086" accept-charset="UTF-8">
+        <div>
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-name">
+            <label for="edit-submitted-name">Name <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-name" name="name" value="" size="60" maxlength="128" class="form-text required" />
+          </div>
+          <div class="form-item webform-component webform-component-email" id="webform-component-email">
+            <label for="edit-submitted-email">Email <span class="form-required" title="This field is required.">*</span></label>
+            <input class="email form-text form-email required" type="email" id="edit-submitted-email" name="email" size="60" />
+          </div>
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-project-name">
+            <label for="edit-submitted-project-name">Project Name <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-project-name" name="project_name" value="" size="60" maxlength="128" class="form-text required" />
+            <div class="description">Name of the open source project or education institution this request will be supporting.</div>
+          </div>
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-project-url">
+            <label for="edit-submitted-project-url">Project URL <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-project-url" name="project_url" value="" size="60" maxlength="128" class="form-text required" />
+            <div class="description">Primary website URL for the open source project or education institution.</div>
+          </div>
+          <div class="form-item webform-component webform-component-textarea" id="webform-component-usage">
+            <label for="edit-submitted-usage">Expected Usage Model <span class="form-required" title="This field is required.">*</span></label>
+            <div class="form-textarea-wrapper resizable"><textarea id="edit-submitted-usage" name="expected_usage_model" cols="60" rows="5" class="form-textarea required"></textarea></div>
+            <div class="description">What types of activity will the machine be used for? (i.e. compile builds, performance testing, architecture troubleshooting, etc).</div>
+          </div>
+          <div class="form-item webform-component webform-component-textfield" id="webform-component-duration">
+            <label for="edit-submitted-duration">Anticipated duration of need <span class="form-required" title="This field is required.">*</span></label>
+            <input type="text" id="edit-submitted-duration" name="anticipated_duration_of_need" value="" size="60" maxlength="128" class="form-text required" />
+            <div class="description">How long do you expect you will need these resources? Ongoing or indefinitely are also acceptable answers.</div>
+          </div>
+          <div class="form-item webform-component webform-component-number" id="webform-component-num-nodes">
+            <label for="edit-submitted-num-nodes">Number of nodes <span class="form-required" title="This field is required.">*</span></label>
+            <input type="number" id="edit-submitted-num-nodes" name="number_of_nodes" value="1" min="1" step="any" class="form-text form-number required" />
+            <div class="description">Estimated number of nodes (machines) you'd like to have.</div>
+          </div>
+          <div class="form-item webform-component webform-component-select" id="webform-component-distribution">
+            <label for="edit-submitted-distribution">Distribution <span class="form-required" title="This field is required.">*</span></label>
+            <select id="edit-submitted-distribution" name="distribution" class="form-select required">
+              <option value="None selected" selected="selected">- Select -</option>
+              <option value="Fedora">Fedora</option>
+              <option value="CentOS">CentOS</option>
+              <option value="Debian">Debian</option>
+              <option value="Ubuntu">Ubuntu</option>
+              <option value="OpenSUSE">OpenSUSE</option>
+              <option value="Other">Other</option>
+            </select>
+            <div class="description">Which Linux distribution would you like to use for your machine? This would likely be the latest stable version available for PPC. If you want a specific version, please state that in the comments section on the last page.</div>
+          </div>
+          <div class="form-item webform-component webform-component-textarea" id="webform-component-ssh-key">
+            <label for="edit-submitted-ssh-key">SSH Public Key <span class="form-required" title="This field is required.">*</span></label>
+            <div class="form-textarea-wrapper resizable"><textarea id="edit-submitted-ssh-key" name="ssh_public_key" cols="60" rows="5" class="form-textarea required"></textarea></div>
+            <div class="description">Public SSH key to be used for initial access to the system.</div>
+          </div>
+          <div class="form-item webform-component webform-component-select" id="webform-component-deployment-timeframe">
+            <label for="edit-submitted-deployment-timeframe">Deployment timeframe </label>
+            <select id="edit-submitted-deployment-timeframe" name="deployment_timeframe" class="form-select">
+              <option value="Within 7 business Days" selected="selected">Within 7 business Days</option>
+              <option value="Within 3 business Days">Within 3 business Days</option>
+              <option value="Within 1 business Days">Within 1 business Day</option>
+            </select>
+            <div class="description">Normal turnaround for access is typically 7 business days. If you need it sooner than that, please choose which time frame you need. We will do our best to accommodate your request. </div>
+          </div>
+          <div class="form-item webform-component webform-component-textarea" id="webform-component-other-information">
+            <label for="edit-submitted-other-information">Other information </label>
+            <div class="form-textarea-wrapper resizable"><textarea id="edit-submitted-other-information" name="other_information" cols="60" rows="5" class="form-textarea"></textarea></div>
+            <div class="description">Is there anything additional you would like to provide for your request?</div>
+          </div>
+
+          <p><i>You should receive an automated email from our request ticketing system to the email address you have provided
+          within 5-10 minutes.  If you don't receive this email please reach out to us at <a href="mailto:powerdev-request@osuosl.org">powerdev-request@osuosl.org</a> or
+          via IRC in <b>#osuosl</b> on Freenode.</i></p>
+
+          <!-- Formsender Settings -->
+          <input type="hidden" name="last_name" value="" />
+          <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
+          <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_hosting in production -->
+          <input type="hidden" name="redirect" value="http://www.osuosl.org/services/powerdev/request_gpu" />
+          <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
+          <input type="hidden" name="mail_subject_key" value="project_name" />
+          <input type="hidden" name="send_to" value="powerdev" />
+          <!-- /Formsender Settings -->
+
+          <div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Submit" class="form-submit" /></div>
+        </div>
+      </form>
+    </div>

--- a/content/forms/openpower-gpu-request.rst
+++ b/content/forms/openpower-gpu-request.rst
@@ -12,7 +12,13 @@ PowerLinux / OpenPOWER Request Form
       <div class="field field-name-body field-type-text-with-summary field-label-hidden">
         <div class="field-items">
           <div class="field-item even" property="content:encoded">
-          <p>Description here.</p>
+          <p>Please use the form below to request hosting on the OpenPOWER GPU POWER environment hosted at the
+          OSUOSL.</p>
+          <p>The OpenPOWER GPU development infrastructure was created to provide developers access to new NVIDIA GPU
+          technologies hosted on the OpenPOWER platform. Access to these resources are limited and we ask you provide
+          us with the information below so we can find the best way to provide the resources you are requesting for GPU
+          based development. If there are questions or concerns about access as well as requests that require large
+          amounts of resources, please provide details in the "Other information" section.</p>
           </div>
         </div>
       </div>
@@ -55,12 +61,8 @@ PowerLinux / OpenPOWER Request Form
             <label for="edit-submitted-distribution">Distribution <span class="form-required" title="This field is required.">*</span></label>
             <select id="edit-submitted-distribution" name="distribution" class="form-select required">
               <option value="None selected" selected="selected">- Select -</option>
-              <option value="Fedora">Fedora</option>
               <option value="CentOS">CentOS</option>
-              <option value="Debian">Debian</option>
               <option value="Ubuntu">Ubuntu</option>
-              <option value="OpenSUSE">OpenSUSE</option>
-              <option value="Other">Other</option>
             </select>
             <div class="description">Which Linux distribution would you like to use for your machine? This would likely be the latest stable version available for PPC. If you want a specific version, please state that in the comments section on the last page.</div>
           </div>

--- a/content/forms/power-request-hosting.rst
+++ b/content/forms/power-request-hosting.rst
@@ -1,8 +1,8 @@
 PowerLinux / OpenPOWER Request Form
 ===================================
 :slug: services/powerdev/request_hosting
-:title: PowerLinux / OpenPOWER Request Form
-:menu: POWERLinux/OpenPOWER Development Hosting, PowerLinux/OpenPOWER Request Form, 3
+:title: OpenPOWER OpenStack Request Form
+:menu: POWERLinux/OpenPOWER Development Hosting, OpenPOWER OpenStack Request Form, 3
 
 .. raw:: html
 

--- a/content/services/services_powerdev.rst
+++ b/content/services/services_powerdev.rst
@@ -1,20 +1,22 @@
 PowerLinux / OpenPOWER Development Hosting
 ==========================================
 :slug: services/powerdev
-:title: Development Hosting
+:title: POWER Development Hosting
 :menu: Services, POWERLinux/OpenPOWER Development Hosting, 3
 
 The Open Source Lab partners with `IBM`_ to host `POWER`_ based servers in order
 to provide an open platform for innovation to the open source community. Current
 projects embrace open software projects ranging from KVM to OpenStack and open
-collaboration with `OpenPOWER Foundation`_ partners, including `Mellanox`_,
-`Ubuntu`_ and `Google`_, and open source based ISV and distribution partners,
-such as `Chef`_, Red Hat, SUSE and Ubuntu, who support the latest POWER hardware
-via production and development (Fedora, OpenSUSE, and Debian) distributions.
+collaboration with `OpenPOWER Foundation`_ partners, including `NVIDIA`_,
+`Mellanox`_, `Ubuntu`_ and `Google`_, and open source based ISV and distribution
+partners, such as `Chef`_, Red Hat, SUSE and Ubuntu, who support the latest
+POWER hardware via production and development (Fedora, CentOS, OpenSUSE, and
+Debian) distributions.
 
 .. _IBM: http://www-03.ibm.com/linux/ltc/
 .. _POWER: http://en.wikipedia.org/wiki/IBM_POWER_microprocessors
 .. _OpenPOWER Foundation: http://openpowerfoundation.org
+.. _NVIDIA: http://www.nvidia.com
 .. _Mellanox: https://www.mellanox.com
 .. _Ubuntu: http://www.ubuntu.com
 .. _Google: https://opensource.google.com/
@@ -22,26 +24,30 @@ via production and development (Fedora, OpenSUSE, and Debian) distributions.
 
 Members of the community can use these POWER servers to develop and test open
 source projects on the `Power Architecture`_ platform and in a `PowerLinux`_
-environment. These shared systems are intended for functional development and
-testing work, but are not ideal for performance testing. Developers looking for
-assistance can go to the `Linux on IBM Power Systems Developer`_ portal or `IBM
-Portal for OpenPOWER`_.
+environment. Developers looking for assistance can go to the `Linux on IBM Power
+Systems Developer`_ portal or `IBM Portal for OpenPOWER`_.
 
 .. _Power Architecture: http://en.wikipedia.org/wiki/Power_Architecture
 .. _PowerLinux: http://en.wikipedia.org/wiki/PowerLinux
 .. _Linux on IBM Power Systems Developer: https://developer.ibm.com/linuxonpower/
 .. _IBM Portal for OpenPOWER: https://www-355.ibm.com/systems/power/openpower/
 
-We offer POWER8 big or little endian instances running on KVM and providing
-access via OpenStack's API and GUI interface. The POWER8 instances offer much
-more flexibility, giving the ability to spin up or down instances on demand. We
+Two clusters of POWER resources are hosted at the Open Source Lab.
+
+The first is an OpenStack based cluster offering POWER8 (POWER9 once available)
+LE instances running on KVM and providing access via OpenStack's API and GUI
+interface.  These shared systems are intended for functional development and
+continuous integration work, but are not ideal for performance testing.  We
 start projects out with a small quota, but can increase given resource
-availability and justification.
+availability and justification. To request access to an OpenStack POWER
+instance, use our `OpenPOWER OpenStack request form`_.
 
-To request access to a POWER server, use our `request form`_ and we will get
-back to you shortly.
+The second is an OpenPOWER GPU based acceleration cluster offering POWER8+
+"Minsky" servers with NVIDIA P100 GPUs connected via NVLink.  To request access
+to the OpenPOWER GPU cluster, use our `OpenPOWER GPU request form`_.
 
-.. _request form: /services/powerdev/request_hosting
+.. _OpenPOWER OpenStack request form: /services/powerdev/request_hosting
+.. _OpenPOWER GPU request form: /services/powerdev/request_gpu
 
 * List of `Current Projects & Academic Partners`_
 


### PR DESCRIPTION
For #159 

Changes: 
- [x] new OpenPOWER GPU request form based on powerdev form. In the menu, I put it in Services/PowerLinux/OpenPOWER Development Hosting/ , which is where the powerdev form is. Should it be one level up?

TODO:
- [x] new description for the form
- [x] verify correct email? ~~Currently we have powerdev-request@osuosl.org specified at the bottom of the form, which is also where the form currently routes its email to.~~ openpower-gpu-support@osuosl.org