### PR TITLE
Add student position blog post for Feb 2018

### DIFF
--- a/content/blog/posts/we-are-hiring-feb-2018.rst
+++ b/content/blog/posts/we-are-hiring-feb-2018.rst
@@ -1,0 +1,19 @@
+We're Hiring!
+=============
+:date: 2018-02-21
+:slug: were-hiring-feb-2018
+:author: Jonathan Frederick
+:img: CASS_group_photo_17.jpg
+:tag: featured-stories
+
+Are you a student at Oregon State University who likes working with open source
+software? If so, then we have a job for you! We currently have two
+`student systems engineer`_ positions open which includes working with open
+source projects, gaining mentorship from professional staff, and interacting
+directly with clients.
+
+Check out our employment_ page to see what you gain when you work with us!
+
+.. _student systems engineer: https://jobs.oregonstate.edu/postings/55739
+
+.. _employment: /about/employment


### PR DESCRIPTION
This PR creates a blog post that is shown on the front page advertising our new student positions.

After these positions are filled I can go back and remove it from the featured stories and edit the post with the updated info.