### PR TITLE
Move CentOS project to former projects list

### DIFF
--- a/content/services/csv/powerdev_former_open_source_projects.csv
+++ b/content/services/csv/powerdev_former_open_source_projects.csv
@@ -1,4 +1,5 @@
 "Alberta Speculation","Investigate multi-threaded speculation of alternative paths of execution in a sequential execution"
+"CentOS","Provided support and testing for alpha testing of CentOS Linux distribution on POWER architecture"
 "Diffusion magnetic resonance imaging of human brain","Drive diffusion basis spectrum imaging (DBSI) for clinical applications and large scale trials for a diffusion MRI modality which can increase the magnetic resonance imaging specificity for neurodegeneration diseases"
 "dlib","A modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++ to solve real world problems. The projects ran tests and benchmarked PowerPC8 VSX optimizations."
 "Drupal Testbots","Powered the testing and review of code contribution for Drupal 8 (qa.drupal.org)"

--- a/content/services/csv/powerdev_open_source_projects.csv
+++ b/content/services/csv/powerdev_open_source_projects.csv
@@ -4,7 +4,6 @@
 "BearSSL","An SSL/TLS library, with a focus on a clean, secure implementation of protocol, up-to-date with the latest research; POWER8 systems writes specific implementations of AES/GCM and other cryptographic algorithms that leverage the specific opcodes offered by the CPU, for better performance"
 "Blockchain","Continuous intergration for IBM Blockchain hyperledger fabric code for POWER"
 "Blosc","PowerPC testing for Blosc, a high performance compressor optmized for binary data"
-"CentOS","Provided support and testing for alpha testing of CentOS Linux distribution on POWER architecture"
 "checkpoint-restore","Implements checkpoint-restore functionality for Linux on POWER architecture; functionality can be used for wide range of use-cases, including live migration, ‘suspend’ and ‘resume’ operations on containers, reboot-less kernel upgrades"
 "Cloud Foundry","Supports porting on POWER, continuous integration and builds integration"
 "CRIU","Supports project specific porting efforts of POWER8 ppc64/ppc64le"


### PR DESCRIPTION
The CentOS project is no longer using our OpenPOWER resources(see discussions on internal
mailing list), so this will move it from our current to former projects list