### PR TITLE
Update hosting to include Mutt's mailing list + website

### DIFF
--- a/content/services/hosting/projects.csv
+++ b/content/services/hosting/projects.csv
@@ -67,7 +67,7 @@ Mozillazine,co-location
 Mulgara,"vm, mailing-list"
 Musescore,mirroring
 Musicbrainz,"vm, mirroring"
-Mutt,mirroring
+Mutt,"mirroring, mailing-list, webapp"
 Mycroft Project,webapp
 MythTV,"co-location, vm, mirroring"
 Mythubuntu,mirroring


### PR DESCRIPTION
In [RT#29921](https://support.osuosl.org/Ticket/Display.html?id=29921) Mutt's requested mailing list hosting and website hosting (in addition to the FTP mirroring we were already doing). This updates the hosted projects list to reflect that.