### PR TITLE
Remove the blog post for February 2018 hiring.

### DIFF
--- a/content/blog/posts/we-are-hiring-feb-2018.rst
+++ b/content/blog/posts/we-are-hiring-feb-2018.rst
@@ -4,7 +4,6 @@ We're Hiring!
 :slug: were-hiring-feb-2018
 :author: Jonathan Frederick
 :img: CASS_group_photo_17.jpg
-:tag: featured-stories
 
 Are you a student at Oregon State University who likes working with open source
 software? If so, then we have a job for you! We currently have two


### PR DESCRIPTION
AFAIK, we don't need this hiring notice anymore.

Alternatively, I could leave the post in there but remove it from the front page, if we want to do that for w/e reason.