### PR TITLE
Added gcc-gfortran and x265 projects

### DIFF
--- a/content/services/csv/powerdev_open_source_projects.csv
+++ b/content/services/csv/powerdev_open_source_projects.csv
@@ -16,7 +16,7 @@
 "Elephant Shed","Provides ppc64le build and performance testing for Elephant Shed, a bundle of PostgreSQL tools and web UI for easy administration of PostgreSQL servers"
 "Firefox","Ports Mozilla Firefox to POWER8"
 "GCC/Clang","Contributes to improved support of GCC and Clang projects on POWER machines by working on IBM Linux Technology Center items on bountysource.com"
-"GNU Fortran", "Compiler optimizations and bug fixing for POWER port of GCC fortran compiler"
+"GCC Fortran", "Compiler optimizations and bug fixing for POWER port of GCC fortran compiler"
 "`Gentoo PowerPC Project`_","Part of Gentoo Linux and is responsible for porting Gentoo to PowerPC architecture of all flavors"
 "Ginga Middleware","ISDB middleware for interactive DTV. Supports project in porting to POWER8"
 "Go Language","Supports project specific porting efforts of POWER8 ppc64/ppc64le"

--- a/content/services/csv/powerdev_open_source_projects.csv
+++ b/content/services/csv/powerdev_open_source_projects.csv
@@ -16,7 +16,7 @@
 "Elephant Shed","Provides ppc64le build and performance testing for Elephant Shed, a bundle of PostgreSQL tools and web UI for easy administration of PostgreSQL servers"
 "Firefox","Ports Mozilla Firefox to POWER8"
 "GCC/Clang","Contributes to improved support of GCC and Clang projects on POWER machines by working on IBM Linux Technology Center items on bountysource.com"
-"gcc-gfortran", "GNU Compiler for the Fortran programming language"
+"GNU Fortran", "Compiler optimizations and bug fixing for POWER port of GCC fortran compiler"
 "`Gentoo PowerPC Project`_","Part of Gentoo Linux and is responsible for porting Gentoo to PowerPC architecture of all flavors"
 "Ginga Middleware","ISDB middleware for interactive DTV. Supports project in porting to POWER8"
 "Go Language","Supports project specific porting efforts of POWER8 ppc64/ppc64le"

--- a/content/services/csv/powerdev_open_source_projects.csv
+++ b/content/services/csv/powerdev_open_source_projects.csv
@@ -16,6 +16,7 @@
 "Elephant Shed","Provides ppc64le build and performance testing for Elephant Shed, a bundle of PostgreSQL tools and web UI for easy administration of PostgreSQL servers"
 "Firefox","Ports Mozilla Firefox to POWER8"
 "GCC/Clang","Contributes to improved support of GCC and Clang projects on POWER machines by working on IBM Linux Technology Center items on bountysource.com"
+"gcc-gfortran", "GNU Compiler for the Fortran programming language"
 "`Gentoo PowerPC Project`_","Part of Gentoo Linux and is responsible for porting Gentoo to PowerPC architecture of all flavors"
 "Ginga Middleware","ISDB middleware for interactive DTV. Supports project in porting to POWER8"
 "Go Language","Supports project specific porting efforts of POWER8 ppc64/ppc64le"

--- a/content/services/current_POWERdev_projects.rst
+++ b/content/services/current_POWERdev_projects.rst
@@ -14,7 +14,7 @@ academic partners.
 `OpenPOWER GPU Projects`_
 
 .. _`FOSS Projects`:
-.. csv-table:: FOSS Projects (69 projects)
+.. csv-table:: FOSS Projects (70 projects)
    :class: powerdev-tbl
    :file: ./csv/powerdev_open_source_projects.csv
    :widths: 20,80


### PR DESCRIPTION
gcc-gfortran ticket: https://support.osuosl.org/Ticket/Display.html?id=30067
x265 ticket: https://support.osuosl.org/Ticket/Display.html?id=30068

did not have to add pelican entry because there was already a project created for x265