### PR TITLE
Ensure build directory exists before running pelican

### DIFF
--- a/develop_server.sh
+++ b/develop_server.sh
@@ -62,6 +62,7 @@ function shut_down(){
 function start_up(){
   local port=$1
   echo "Starting up Pelican and HTTP server"
+  test -d $OUTPUTDIR || mkdir $OUTPUTDIR
   shift
   $PELICAN --debug --autoreload -r $INPUTDIR -o $OUTPUTDIR -s $CONFFILE $PELICANOPTS &
   pelican_pid=$!


### PR DESCRIPTION
If the `build` directory doesn't exist, and you run `make devserver`, then the root directory for the webserver **might** not exist in time, leading the `cd build` command to fail, putting the webserver root in the git repo directory instead of the `build` directory. This PR ensures the build directory exists no matter what before the `cd` command is run