### PR TITLE
Move ICU to build-farm, remove ICU power project

### DIFF
--- a/content/services/csv/powerdev_former_open_source_projects.csv
+++ b/content/services/csv/powerdev_former_open_source_projects.csv
@@ -8,6 +8,7 @@
 "The Genome Analysis Toolkit (GATK)","A software package for analysis of high-throughput sequencing data with a primary focus on variant discovery and genotyping as well as strong emphasis on data quality assurance, hosted on POWER architecture to run faster"
 "GLIBC","GNU C Library: GNU project's implementation of the C standard library; supported the development and testing on the POWER platform"
 "GMP","Entailed the compilation of gmp-6.1.0 (from gmplib.org) and measurement of its performance with gmpbench-0.2 on the POWER platform"
+"ICU","The International Components for Unicode project runs their build machines on a OSL hosted POWER VM"
 "JXcore on PPC","Supports the platforms that the mainstream node.js does not; IBM has a PPC version of V8; Besides V8, JXcore also implements SpiderMonkey engine; project involved providing stable PPC releases on each version of Node.JS / JXcore"
 "MulticoreWare x265","Use GCC PowerPC altivec instructions to optimize the x265 open source HEVC implemenation"
 "MySQL","Involved testing on POWER8, provide fixes to platform specific bugs and make more stable on POWER8"

--- a/content/services/csv/powerdev_open_source_projects.csv
+++ b/content/services/csv/powerdev_open_source_projects.csv
@@ -31,7 +31,6 @@
 "Goy.Chat","An open source platform powered by Meteor uses the POWER infrastructure to test deployments on POWER8."
 "Hadoop_Spark","CI environment powered by a Jenkins server running Hadoop and Spark builds for including POWER into the Hyperledger fabric community to perform Continuous Integration for IBM Hyperledger fabric codebase."
 "Hortonworks Data Platform","A secure, enterprise-ready open source Apache Hadoop distribution based on a centralized architecture (YARN) now on POWER"
-"ICU","The International Components for Unicode project runs their build machines on a OSL hosted POWER VM"
 "Istio","Supports compiling and testing Istio, a platform for microservice management, on POWER"
 "Jellyfish","A fast multi-threaded k-mer counter. POWER infrastructure is being used to compile builds, performance testing, architecture troubleshooting"
 "juju-charms","Adds ppc64el support to appliance image for building/interfacing with juju, the juju charm store, and assembling charms "

--- a/content/services/current_POWERdev_projects.rst
+++ b/content/services/current_POWERdev_projects.rst
@@ -14,7 +14,7 @@ academic partners.
 `OpenPOWER GPU Projects`_
 
 .. _`FOSS Projects`:
-.. csv-table:: FOSS Projects (90 projects)
+.. csv-table:: FOSS Projects (89 projects)
    :class: powerdev-tbl
    :file: ./csv/powerdev_open_source_projects.csv
    :widths: 20,80

--- a/content/services/former_POWERdev_projects.rst
+++ b/content/services/former_POWERdev_projects.rst
@@ -7,7 +7,7 @@ Formerly Hosted Projects
 Below are a list of projects formerly hosted on the OpenPOWER infrastructure at
 the OSL.
 
-.. csv-table:: Former FOSS Projects (17 projects)
+.. csv-table:: Former FOSS Projects (19 projects)
    :class: powerdev-tbl
    :file: ./csv/powerdev_former_open_source_projects.csv
    :widths: 20,80

--- a/content/services/hosting/projects.csv
+++ b/content/services/hosting/projects.csv
@@ -67,7 +67,6 @@
 "Harmony Agreements","webapp, mailing-list"
 "HHVM","mirroring, powerpc"
 "Hortonworks Data Platform","powerpc"
-"ICU","powerpc"
 "Inkscape","vm, mailing-list"
 "Istio","powerpc"
 "Jaws","vm, mailing-list"


### PR DESCRIPTION
This removes the ICU openpower project, and adds the ICU `build-farm` info to the projects list.

https://support.osuosl.org/Ticket/Display.html?id=30592