### PR TITLE
Remove SIGKILL from kill command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ else
 endif
 
 stopserver:
-	kill -9 `cat pelican.pid`
-	kill -9 `cat srv.pid`
+	kill `cat pelican.pid`
+	kill `cat srv.pid`
 	@echo 'Stopped Pelican and SimpleHTTPServer processes running in background.'
 
 publish:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ help:
 	@echo '   make publish                     generate using production settings '
 	@echo '   make serve [PORT=8000]           serve site at http://localhost:8000'
 	@echo '   make devserver [PORT=8000]       start/restart develop_server.sh    '
-	@echo '   make stopserver                  stop local server                  '
+	@echo '   make stopdevserver               stop dev server                    '
 	@echo '   make rsync_copy                  copy the web site locally via rsync'
 	@echo '   make ssh_upload                  upload the web site via SSH        '
 	@echo '   make rsync_upload                upload the web site via rsync+ssh  '
@@ -80,7 +80,7 @@ else
 	$(BASEDIR)/develop_server.sh restart
 endif
 
-stopserver:
+stopdevserver:
 	kill `cat pelican.pid`
 	kill `cat srv.pid`
 	@echo 'Stopped Pelican and SimpleHTTPServer processes running in background.'


### PR DESCRIPTION
`-9` option is not necessary.
Based on [a comment](https://github.com/osuosl/beaver-barcamp-pelican/pull/53#discussion_r295066966) from [osuosl/beaver-barcamp-pelican](https://github.com/osuosl/osuosl-pelican)