### PR TITLE
Replace http loading with https

### DIFF
--- a/content/html/ibm-z-request-ci.html
+++ b/content/html/ibm-z-request-ci.html
@@ -134,7 +134,7 @@
       <!-- Formsender Settings -->
       <input type="hidden" name="last_name" value="" />
       <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
-      <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
+      <input type="hidden" name="redirect" value="https://www.osuosl.org/form-submitted" />
       <input type="hidden" name="mail_subject_prefix" value="New IBM Z CI Request" />
       <input type="hidden" name="mail_subject_key" value="project_name" />
       <input type="hidden" name="send_to" value="ibm-z-ci" />

--- a/content/html/openpower-gpu-request.html
+++ b/content/html/openpower-gpu-request.html
@@ -156,7 +156,7 @@
       <input type="hidden" name="last_name" value="" />
       <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
       <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_gpu in production -->
-      <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
+      <input type="hidden" name="redirect" value="https://www.osuosl.org/form-submitted" />
       <input type="hidden" name="mail_subject_prefix" value="New OpenPOWER GPU Request" />
       <input type="hidden" name="mail_subject_key" value="project_name" />
       <input type="hidden" name="send_to" value="openpower_gpu" />

--- a/content/html/power-request-ci.html
+++ b/content/html/power-request-ci.html
@@ -133,7 +133,7 @@
           <option value="No" selected="selected">No</option>
           <option value="Yes">Yes</option>
         </select>
-        <div class="description">Thanks to a collaboration with the <a href="http://cgrb.oregonstate.edu/">Center for
+        <div class="description">Thanks to a collaboration with the <a href="https://cgrb.oregonstate.edu/">Center for
         Genome Research and Biocomputing (CGRB)</a>, our POWER CI system does have access to GPU's via Jenkins. If you
         require GPU access, please answer "Yes".</div>
       </div>
@@ -154,7 +154,7 @@
       <!-- Formsender Settings -->
       <input type="hidden" name="last_name" value="" />
       <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
-      <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
+      <input type="hidden" name="redirect" value="https://www.osuosl.org/form-submitted" />
       <input type="hidden" name="mail_subject_prefix" value="New POWER CI Request" />
       <input type="hidden" name="mail_subject_key" value="project_name" />
       <input type="hidden" name="send_to" value="power-ci" />

--- a/content/html/power-request-hosting.html
+++ b/content/html/power-request-hosting.html
@@ -174,7 +174,7 @@
       <input type="hidden" name="last_name" value="" />
       <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
       <!-- The following must be set to http://www.osuosl.org/services/powerdev/request_hosting in production -->
-      <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
+      <input type="hidden" name="redirect" value="https://www.osuosl.org/form-submitted" />
       <input type="hidden" name="mail_subject_prefix" value="New PowerLinux/OpenPOWER Hosting Request" />
       <input type="hidden" name="mail_subject_key" value="project_name" />
       <input type="hidden" name="send_to" value="powerdev" />

--- a/content/html/request-hosting.html
+++ b/content/html/request-hosting.html
@@ -90,7 +90,7 @@
           <input type="hidden" name="token"
           value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
           <!-- The following must be set to http://www.osuosl.org/request-hosting in production -->
-          <input type="hidden" name="redirect" value="http://www.osuosl.org/form-submitted" />
+          <input type="hidden" name="redirect" value="https://www.osuosl.org/form-submitted" />
           <input type="hidden" name="mail_subject_prefix" value="New Hosting Request" />
           <input type="hidden" name="mail_subject_key" value="project_name" />
           <input type="hidden" name="send_to" value="hosting_request" />

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -46,7 +46,7 @@ PAGINATED_DIRECT_TEMPLATES = ['blog', 'tags']
 DIRECT_TEMPLATE_INFO = [
         {'parent': u'top', 'link': '/blog', 'name': 'Blog', 'weight': 5, 'children': []}]  # noqa
 
-DONATE_LINK = 'http://osuosl.org/donate'
+DONATE_LINK = 'https://osuosl.org/donate'
 
 THEME = 'dougfir-pelican-theme'
 
@@ -89,17 +89,17 @@ DEFAULT_DATE = 'fs'
 USE_FOLDER_AS_CATEGORY = True
 
 # Social media
-TWITTERURL = 'http://twitter.com/osuosl'
-FACEBOOKURL = 'http://facebook.com/osuosl'
+TWITTERURL = 'https://twitter.com/osuosl'
+FACEBOOKURL = 'https://facebook.com/osuosl'
 GITHUBURL = 'https://github.com/osuosl'
-YOUTUBEURL = 'http://youtube.com/osuopensourcelab'
+YOUTUBEURL = 'https://youtube.com/osuopensourcelab'
 GPLUSURL = 'https://plus.google.com/107361178205293595706?rel=author'
 
 GOOGLE_ANALYTICS = 'UA-537692-1'
 
 DEP_NAME = 'OSU Open Source Lab'
 PARENT_ORG = 'Center for Applied Systems & Software'
-PARENT_ORG_URL = 'http://cass.oregonstate.edu/'
+PARENT_ORG_URL = 'https://cass.oregonstate.edu/'
 OSLLOGO = 'osllogo-web_0.png'
 SITELOGO = 'milne_street.png'
 SITELOG_URL = 'https://www.google.com/maps/place/Milne+Computer+Center,+1800+SW+Campus+Way,+Corvallis,+OR+97331'  # noqa


### PR DESCRIPTION
All browsers warn about "part of this page is insecure". This is caused by the page loading http sources and links instead of https. [1,2] There are many occurrence of http loading throughout the
site. This requires a site-wide replacement of http loading to https. 

Because I have not verified if formsender supports https, this commit does not update formsender link, which remain a must-have TODO item for this change [WIP]

This change depends on the PR https://github.com/osuosl/dougfir-pelican-theme/pull/86 to submodule `dougfir-pelican-theme` contained in this repository. Thus, you may see some changes on `dougfir-pelican-theme`. Please let me know if this should be reverted and wait for that PR to comes through later.

[1]
https://stackoverflow.com/questions/34273230/firefox-some-parts-of-this-page-are-not-secure-such-as-images-what-counts-a

[2] https://knowledge.digicert.com/solution/SO3059.html