### PR TITLE
Add PicaLibre to hosted projects

### DIFF
--- a/content/services/hosting/projects.csv
+++ b/content/services/hosting/projects.csv
@@ -155,6 +155,7 @@
 "perfbook","powerpc"
 "pgSphere","powerpc"
 "phpBB","co-location, vm, mirroring"
+"PicaLibre","vm"
 "postgreSQL","powerpc"
 "PowerPC Notebook","powerpc"
 "Presto","powerpc"


### PR DESCRIPTION
Since we're not actually hosting this project on the ftp server, I only put them down as `vm`. Should I also include mirroring even though its not on the ftp server?