### PR TITLE
Changed Github Username

### DIFF
--- a/content/about/about_people.rst
+++ b/content/about/about_people.rst
@@ -242,7 +242,7 @@ Starting in November of 2022, Zach was brought aboard during his Junior year of 
 
   **GitHub Account**
 
-https://github.com/sectopodwreck
+https://github.com/zwall-bp
 
 .. class:: no-breaks
 


### PR DESCRIPTION
After changing usernames, any links associated with the old one are dead. So, this is a quick patch to the OSL website.