### PR TITLE
Remove MSYS2 from AARCH64 hosted projects

### DIFF
--- a/content/services/csv/aarch64_former_open_source_projects.csv
+++ b/content/services/csv/aarch64_former_open_source_projects.csv
@@ -1,2 +1,3 @@
 "gVisor", "Provide isolation for containers, so that the overall system remains secure."
+"MSYS2","MSYS2 is a collection of tools and libraries providing you with an easy-to-use environment for building, installing and running native Windows software."
 "Skytable", "Skytable is an insanely fast, free and open-source, realtime NoSQL database that aims to provide flexible data modeling without compromising on performance or queryability — at scale."

--- a/content/services/csv/aarch64_open_source_projects.csv
+++ b/content/services/csv/aarch64_open_source_projects.csv
@@ -19,7 +19,6 @@ compatible with RHEL® and pre-CentOS-Stream CentOS™ (e.g. CentOS 8.3). Founde
 "Jitesoft", "Jitesoft strive to provide up-to-date, optimized and secure docker/oci images for multiple architectures, free of charge. All images and build-scripts are released under the MIT license and can be found on GitLab and GitHub. https://gitlab.com/jitesoft/dockerfiles"
 "Kali Linux", "Kali Linux is an open-source, multi-platform distribution, aimed at advanced Penetration Testing and Security Auditing. Kali Linux provides several hundred common tools and industry specific modifications, targeted towards various information security tasks, such as Penetration Testing, Security Research, Computer Forensics, Reverse Engineering, Vulnerability Management and Red Team Testing."
 "Minio","Testing minio object storage server on ARM architecture."
-"MSYS2","MSYS2 is a collection of tools and libraries providing you with an easy-to-use environment for building, installing and running native Windows software."
 "Node.js", "Node.js is a JavaScript runtime for servers. It runs on a variety of OS and architecture platforms (https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list for the current list), including Linux on AARCH64 (arm64)."
 "OpenDev","OpenDev is a collaboratory for open source software development at scale. CI nodes supporting projects such as Openstack, Airship, Kata, pypa/pip, pyca/cryptography etc."
 "OpenFaaS","Making Serverless Functions Simple. Troubleshooting and development of ARM64 support for builds (to create artifacts) and function templates."

--- a/content/services/current_AARCH64_projects.rst
+++ b/content/services/current_AARCH64_projects.rst
@@ -9,7 +9,7 @@ Below are a list of currently hosted AARCH64 projects
 `FOSS Projects`_
 
 .. _`FOSS Projects`:
-.. csv-table:: FOSS Projects (34 projects)
+.. csv-table:: FOSS Projects (35 projects)
    :class: powerdev-tbl
    :file: ./csv/aarch64_open_source_projects.csv
    :widths: 20,80

--- a/content/services/former_AARCH64_projects.rst
+++ b/content/services/former_AARCH64_projects.rst
@@ -7,7 +7,7 @@ Formerly Hosted Projects
 Below are a list of projects formerly hosted on the aarch64 infrastructure at
 the OSL.
 
-.. csv-table:: Former FOSS Projects (2 projects)
+.. csv-table:: Former FOSS Projects (3 projects)
    :class: aarch64-tbl
    :file: ./csv/aarch64_former_open_source_projects.csv
    :widths: 20,80


### PR DESCRIPTION
We couldn't make use of it and from what I see it's not active, see https://github.com/msys2/msys2-autobuild/issues/84#issuecomment-1963298185